### PR TITLE
Fix documentation of <<$>>

### DIFF
--- a/src/Control/Biapply.purs
+++ b/src/Control/Biapply.purs
@@ -9,7 +9,7 @@ import Data.Tuple (Tuple(..))
 -- | the style of `Applicative`:
 -- |
 -- | ```purescript
--- | bipure f g <<$>> x <<*>> y
+-- | bimap f g <<$>> x <<*>> y
 -- | ```
 infixl 4 identity as <<$>>
 


### PR DESCRIPTION
**Description of the change**

Per #24, the current documentation for the `(<<$>>)` does not typecheck. This PR fixes the documentation to what I imagine was the intended code.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
