### PR TITLE
Add bivoid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+  - Added `bivoid` 
 
 Bugfixes:
 

--- a/src/Data/Bifunctor.purs
+++ b/src/Data/Bifunctor.purs
@@ -4,6 +4,8 @@ import Control.Category (identity)
 import Data.Const (Const(..))
 import Data.Either (Either(..))
 import Data.Tuple (Tuple(..))
+import Data.Unit (Unit, unit)
+import Data.Function (const)
 
 -- | A `Bifunctor` is a `Functor` from the pair category `(Type, Type)` to `Type`.
 -- |
@@ -28,6 +30,10 @@ lmap f = bimap f identity
 -- | Map a function over the second type arguments of a `Bifunctor`.
 rmap :: forall f a b c. Bifunctor f => (b -> c) -> f a b -> f a c
 rmap = bimap identity
+
+-- | The bivoid function is used to ignore the types wrapped by a Bifunctor.
+bivoid :: forall f a b. Bifunctor f => f a b -> f Unit Unit
+bivoid = bimap (const unit) (const unit)
 
 instance bifunctorEither :: Bifunctor Either where
   bimap f _ (Left l) = Left (f l)


### PR DESCRIPTION
In analogy of [void](https://pursuit.purescript.org/packages/purescript-prelude/6.0.2/docs/Data.Functor#v:void) for Functor, this PR adds `bivoid` of type  `Bifunctor f => f a b -> f Unit Unit` to the library.


**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
